### PR TITLE
Allow httparty ~> 0.9

### DIFF
--- a/persistent_httparty.gemspec
+++ b/persistent_httparty.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.test_files       = `git ls-files -- {spec,features}/*`.split("\n")
   gem.require_paths = ["lib"]
 
-  gem.add_dependency "httparty", "~> 0.9.0"
+  gem.add_dependency "httparty", "~> 0.9"
   gem.add_dependency "persistent_http"
 
   gem.add_development_dependency "rake"


### PR DESCRIPTION
Everything works fine with httparty 0.10.0, and I think allowing future point releases is reasonable.
