### PR TITLE
Set requirement on persistent_http >= 2.0.1

### DIFF
--- a/lib/persistent_httparty/version.rb
+++ b/lib/persistent_httparty/version.rb
@@ -1,3 +1,3 @@
 module PersistentHttparty
-  VERSION = "0.1.2"
+  VERSION = "0.1.3"
 end

--- a/persistent_httparty.gemspec
+++ b/persistent_httparty.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
   else
     gem.add_dependency "httparty", ">= 0.9", "< 0.12"
   end
-  gem.add_dependency "persistent_http", "< 2"
+  gem.add_dependency "persistent_http", ">= 2.0.1"
 
   gem.add_development_dependency "rake"
   gem.add_development_dependency "rspec", "~> 2.13.0"


### PR DESCRIPTION
Looks like persistent_http 2.0.1 may have fixed whatever was broken with the move to version 2.0.0. I have run this branch in my project using persistent_http 2.0.1 and all seems fine.

https://github.com/bpardee/persistent_http/commit/2953c48bd03da118655d1687009d8ccb0f557a2a

Could be the replacement of the above accessors?

I'll take a look at the failing tests if they still apply. They seem to only exist to verify options that used to exist at the old `PersistentHTTP` class level that has now been moved to `PersistentHTTP::Connection` class.

I've submitted a pull request against persistent_http to expose the pool instance.
https://github.com/bpardee/persistent_http/pull/7

If this gets adopted, these tests can be adjusted to verify these options at the pool level. Since these options are passed to gene_pool and then that instance is not exposed, these options cannot be verified.