### PR TITLE
Fix deprecations and warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,11 @@
 language: ruby
 rvm:
-  - 1.8.7
-  - 1.9.2
-  - 1.9.3
-  - 2.0.0
-  - 2.1
-  - jruby-18mode
-  - jruby-19mode
+  - 2.3
+  - 2.4
+  - 2.5
+  - 2.6
+  - jruby-9.2.5.0
+  - jruby-9.1.17.0
   - rbx-2
 bundler_args: --without tools darwin
 matrix:

--- a/lib/httparty/persistent/connection_adapter.rb
+++ b/lib/httparty/persistent/connection_adapter.rb
@@ -6,10 +6,7 @@ module HTTParty::Persistent
     attr_accessor :persistent_http
 
     def call(uri, options)
-      if @persistent_http.nil?
-        @persistent_http = build_persistent_http(uri, options)
-      end
-      @persistent_http
+      @persistent_http ||= build_persistent_http(uri, options)
     end
 
     def build_persistent_http(uri, options)

--- a/persistent_httparty.gemspec
+++ b/persistent_httparty.gemspec
@@ -25,7 +25,8 @@ Gem::Specification.new do |gem|
   gem.add_dependency "persistent_http", "< 2"
 
   gem.add_development_dependency "rake"
-  gem.add_development_dependency "rspec", "~> 2.13.0"
+  gem.add_development_dependency "rspec", "~> 3.8"
+  gem.add_development_dependency "rspec-its"
   gem.add_development_dependency "cucumber"
   gem.add_development_dependency "webmock"
 end

--- a/spec/lib/httparty/persistent/connection_adapter_spec.rb
+++ b/spec/lib/httparty/persistent/connection_adapter_spec.rb
@@ -11,24 +11,24 @@ describe HTTParty::Persistent::ConnectionAdapter do
     subject { adapter.call(uri, options) }
 
     it "returns a PersistentHTTP" do
-      subject.should be_a PersistentHTTP
+      is_expected.to be_a PersistentHTTP
     end
 
     it "returns the same PersistentHTTP across calls" do
-      adapter.call(uri, options).should be subject
+      expect(adapter.call(uri, options)).to be subject
     end
 
     describe "the resulting PersistentHTTP" do
       subject { adapter.call(uri, options) }
 
-      it { should_not be_nil }
-      it { should be_instance_of PersistentHTTP }
-      its(:host) { should == uri.host }
-      its(:port) { should == uri.port }
+      it { is_expected.to_not be_nil }
+      it { is_expected.to be_instance_of PersistentHTTP }
+      its(:host) { is_expected.to eq uri.host }
+      its(:port) { is_expected.to eq uri.port }
 
       it "is the same across multiple calls" do
-        adapter.call(uri, options).should be subject
-        adapter.call(uri, options).should be subject
+        expect(adapter.call(uri, options)).to be subject
+        expect(adapter.call(uri, options)).to be subject
       end
 
       context "when dealing with ssl" do
@@ -40,22 +40,22 @@ describe HTTParty::Persistent::ConnectionAdapter do
 
         context "using port 443 for ssl" do
           let(:uri) { URI 'https://api.foo.com/v1:443' }
-          it { should use_ssl }
+          it { is_expected.to use_ssl }
         end
 
         context "using port 80" do
           let(:uri) { URI 'http://foobar.com' }
-          it { should_not use_ssl }
+          it { is_expected.not_to use_ssl }
         end
 
         context "https scheme with default port" do
           let(:uri) { URI 'https://foobar.com' }
-          it { should use_ssl }
+          it { is_expected.to use_ssl }
         end
 
         context "https scheme with non-standard port" do
           let(:uri) { URI 'https://foobar.com:123456' }
-          it { should use_ssl }
+          it { is_expected.to use_ssl }
         end
       end
 
@@ -63,16 +63,16 @@ describe HTTParty::Persistent::ConnectionAdapter do
         context "to 5 seconds" do
           let(:options) { {:timeout => 5} }
 
-          its(:open_timeout) { should == 5 }
-          its(:read_timeout) { should == 5 }
+          its(:open_timeout) { is_expected.to eq 5 }
+          its(:read_timeout) { is_expected.to eq 5 }
         end
 
         context "and timeout is a string" do
           let(:options) { {:timeout => "five seconds"} }
 
           it "doesn't set the timeout" do
-            subject.open_timeout.should be_nil
-            subject.read_timeout.should be_nil
+            expect(subject.open_timeout).to be_nil
+            expect(subject.read_timeout).to be_nil
           end
         end
       end
@@ -81,14 +81,14 @@ describe HTTParty::Persistent::ConnectionAdapter do
         context "is set to $stderr" do
           let(:options) { {:debug_output => $stderr} }
           it "has debug output set" do
-            subject.debug_output.should == $stderr
+            expect(subject.debug_output).to eq $stderr
           end
         end
 
         context "is not provided" do
           let(:options) { {} }
           it "does not set_debug_output" do
-            subject.debug_output.should be_nil
+            expect(subject.debug_output).to be_nil
           end
         end
       end
@@ -96,7 +96,7 @@ describe HTTParty::Persistent::ConnectionAdapter do
       context 'when providing proxy address and port' do
         let(:options) { {:http_proxyaddr => '1.2.3.4', :http_proxyport => 8080} }
 
-        its(:proxy_uri) { should == URI.parse('http://1.2.3.4:8080') }
+        its(:proxy_uri) { is_expected.to eq URI.parse('http://1.2.3.4:8080') }
 
         context 'as well as proxy user and password' do
           let(:options) do
@@ -107,7 +107,7 @@ describe HTTParty::Persistent::ConnectionAdapter do
             uri = URI.parse('http://1.2.3.4:8080')
             uri.user = 'user'
             uri.password = 'pass'
-            should == uri
+            is_expected.to eq uri
           end
         end
       end
@@ -118,21 +118,21 @@ describe HTTParty::Persistent::ConnectionAdapter do
 
         context "when scheme is https" do
           let(:uri) { URI 'https://google.com' }
-          let(:cert) { mock("OpenSSL::X509::Certificate") }
-          let(:key) { mock("OpenSSL::PKey::RSA") }
+          let(:cert) { instance_double(OpenSSL::X509::Certificate) }
+          let(:key) { instance_double(OpenSSL::PKey::RSA) }
 
           before do
-            OpenSSL::X509::Certificate.should_receive(:new).with(pem).and_return(cert)
-            OpenSSL::PKey::RSA.should_receive(:new).with(pem, "password").and_return(key)
+            expect(OpenSSL::X509::Certificate).to receive(:new).with(pem).and_return(cert)
+            expect(OpenSSL::PKey::RSA).to receive(:new).with(pem, "password").and_return(key)
           end
 
           it "uses the provided PEM certificate " do
-            subject.cert.should == cert
-            subject.key.should == key
+            expect(subject.cert).to eq cert
+            expect(subject.key).to eq key
           end
 
           it "will verify the certificate" do
-            subject.verify_mode.should == OpenSSL::SSL::VERIFY_PEER
+            expect(subject.verify_mode).to eq OpenSSL::SSL::VERIFY_PEER
           end
         end
 
@@ -141,16 +141,16 @@ describe HTTParty::Persistent::ConnectionAdapter do
           let(:http) { Net::HTTP.new(uri) }
 
           before do
-            Net::HTTP.stub(:new => http)
-            OpenSSL::X509::Certificate.should_not_receive(:new).with(pem)
-            OpenSSL::PKey::RSA.should_not_receive(:new).with(pem, "password")
-            http.should_not_receive(:cert=)
-            http.should_not_receive(:key=)
+            allow(Net::HTTP).to receive(:new).and_return(http)
+            expect(OpenSSL::X509::Certificate).to_not receive(:new).with(pem)
+            expect(OpenSSL::PKey::RSA).to_not receive(:new).with(pem, "password")
+            expect(http).to receive(:cert=)
+            expect(http).to receive(:key=)
           end
 
           it "has no PEM certificate " do
-            subject.cert.should be_nil
-            subject.key.should be_nil
+            expect(subject.cert).to be_nil
+            expect(subject.key).to be_nil
           end
         end
       end

--- a/spec/lib/httparty/persistent_spec.rb
+++ b/spec/lib/httparty/persistent_spec.rb
@@ -8,7 +8,7 @@ describe HTTParty::Persistent do
 
   describe HTTParty do
     it "includes HTTParty::Persistent" do
-      HTTParty::ClassMethods.should include_module(HTTParty::Persistent::ClassMethods)
+      expect(HTTParty::ClassMethods).to include_module(HTTParty::Persistent::ClassMethods)
     end
 
     context "across multiple requests" do
@@ -16,7 +16,7 @@ describe HTTParty::Persistent do
 
       it "reuses the same http connection" do
         http = Net::HTTP.new(base_uri.host, base_uri.port)
-        Net::HTTP.should_receive(:new).once().and_return(http)
+        expect(Net::HTTP).to receive(:new).once().and_return(http)
 
         stub_request(:get, "#{base_uri.to_s}/status").
           to_return(:status => 200, :body => "", :headers => {})
@@ -37,7 +37,7 @@ describe HTTParty::Persistent do
     before(:each) { klass.persistent_connection_adapter }
 
     it "sets the connection_adapter to HTTParty::Persistent::ConnectionAdapter" do
-      klass.connection_adapter.should be_a HTTParty::Persistent::ConnectionAdapter
+      expect(klass.connection_adapter).to be_a HTTParty::Persistent::ConnectionAdapter
     end
 
     context "with connection_adapter_options" do
@@ -45,7 +45,7 @@ describe HTTParty::Persistent do
       before(:each) { klass.persistent_connection_adapter(connection_adapter_options) }
 
       it "sets the connection_adapter_options that are passed to it" do
-        klass.default_options[:connection_adapter_options].should == connection_adapter_options
+        expect(klass.default_options[:connection_adapter_options]).to eq connection_adapter_options
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,13 +7,13 @@
 
 require 'persistent_httparty'
 require 'webmock/rspec'
+require 'rspec/its'
 
 app_root = File.expand_path(File.join(File.dirname(__FILE__), '..'))
 
 Dir[File.join(app_root, "spec/support/**/*.rb")].each {|f| require f}
 
 RSpec.configure do |config|
-  config.treat_symbols_as_metadata_keys_with_true_values = true
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
 


### PR DESCRIPTION
- Update rspec
- Remove `./home/travis/.rvm/gems/ruby-2.3.7/gems/persistent_httparty-0.1.2/lib/httparty/persistent/connection_adapter.rb:9: warning: instance variable @persistent_http not initialized` warning

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/soupmatt/persistent_httparty/9)
<!-- Reviewable:end -->
